### PR TITLE
Adopt WireMock Extension Gradle convention plugin + Automate releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+# Use https://github.com/wiremock/.github/blob/main/.github/release_drafter.yml
+_extends: .github

--- a/.github/workflows/changelog-draft.yml
+++ b/.github/workflows/changelog-draft.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Determine new version
+        id: new_version
+        run: |
+          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Publish package
+        id: publish_package
+        uses: gradle/gradle-build-action@v2.9.0
+        with:
+          arguments: -Pversion=${{ steps.new_version.outputs.new_version }} publish closeAndReleaseStagingRepository
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -8,13 +8,11 @@ buildscript {
 }
 
 plugins {
-  id 'java-library'
-  id 'signing'
-  id 'maven-publish'
   id 'idea'
   id 'eclipse'
   id 'project-report'
   id 'com.diffplug.spotless' version '6.21.0'
+  id 'org.wiremock.tools.gradle.wiremock-extension-convention' version '0.1.1'
 }
 
 repositories {
@@ -22,38 +20,11 @@ repositories {
   mavenCentral()
 }
 
-group 'org.wiremock'
-version = "0.1.0"
-
-allprojects {
-  sourceCompatibility = 11
-  targetCompatibility = 11
-
+projects {
   ext {
     versions = [
-      wiremock: "3.2.0"
+      wiremock: "3.3.1"
     ]
-
-    repoUser = this.hasProperty('sonatypeUser') ? sonatypeUser : 'default'
-    repoPassword = this.hasProperty('sonatypePassword') ? sonatypePassword : 'default'
-
-    pomInfo = {
-      name 'WireMock Extension for Faker'
-      url 'https://wiremock.org'
-      scm {
-        // TODO setup
-        connection 'https://github.com/wiremock/wiremock-grpc-extension.git'
-        developerConnection 'https://github.com/wiremock/wiremock-grpc-extension.git'
-        url 'https://github.com/wiremock/wiremock-grpc-extension'
-      }
-      licenses {
-        license {
-          name 'The Apache Software License, Version 2.0'
-          url 'http://www.apache.org/license/LICENSE-2.0.txt'
-          distribution 'repo'
-        }
-      }
-    }
   }
 }
 
@@ -88,12 +59,6 @@ dependencies {
   //  1.x is not maintained but we need to use to support Java 11. It is in a better state than java-faker, which is also not maintained. Bump to 2.x once we deprecate support for Java 11.
   implementation 'net.datafaker:datafaker:1.7.0'
 
-  //  testImplementation project(":")
-  testImplementation(platform('org.junit:junit-bom:5.10.0'))
-  testImplementation "org.junit.jupiter:junit-jupiter"
-  testImplementation "org.hamcrest:hamcrest-core:2.2"
-  testImplementation "org.hamcrest:hamcrest-library:2.2"
-  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation("org.wiremock:wiremock:$versions.wiremock") {
     artifact {
       classifier = 'tests'
@@ -101,53 +66,9 @@ dependencies {
   }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-  archiveClassifier.set('sources')
-  from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  archiveClassifier.set('javadoc')
-  from javadoc.destinationDir
-}
-
-task testJar(type: Jar, dependsOn: testClasses) {
-  archiveClassifier.set('tests')
-  from sourceSets.test.output
-}
-
-signing {
-  required {
-    !version.toString().contains("SNAPSHOT") && (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))
-  }
-  sign publishing.publications
-}
-
-publishing {
-  repositories {
-    maven {
-      url 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-      credentials {
-        username repoUser
-        password repoPassword
-      }
-    }
-  }
-
-  publications {
-    main(MavenPublication) { publication ->
-      from components.java
-      artifact sourcesJar
-      artifact javadocJar
-      artifact testJar
-
-      pom.packaging 'jar'
-      pom.withXml {
-        asNode().appendNode('description', 'Add fake data to WireMock responses')
-        asNode().children().last() + pomInfo
-      }
-    }
-  }
+shadowJar {
+  relocate "com.github.jknack", 'wiremock.com.github.jknack'
+  relocate "net.datafaker", 'wiremock.net.datafaker'
 }
 
 test {
@@ -156,16 +77,4 @@ test {
     events "PASSED", "FAILED", "SKIPPED"
     exceptionFormat "full"
   }
-}
-
-project.tasks.signMainPublication.dependsOn jar
-
-assemble.dependsOn clean, jar
-
-task release {
-  dependsOn clean, assemble, publishAllPublicationsToMavenRepository
-}
-
-task localRelease {
-  dependsOn clean, assemble, publishToMavenLocal
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+baseArtifact = wiremock-faker-extension
+version = 1.0.0-SNAPSHOT
+description = Uses https://github.com/datafaker-net/datafaker to generate random, fake data for using in WireMock responses
+githubRepo = wiremock-faker-extension
+developer.id=Shreya-7
+developer.name=Shreya Agarwal
+developer.email=a.shreya202@gmail.com

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,1 @@
-pluginManagement {
-  repositories {
-    gradlePluginPortal()
-    maven {
-      name = "localPluginRepository"
-      url = uri("../local-plugin-repository")
-    }
-  }
-}
-
 rootProject.name = 'wiremock-faker-extension'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,11 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    maven {
+      name = "localPluginRepository"
+      url = uri("../local-plugin-repository")
+    }
+  }
+}
+
 rootProject.name = 'wiremock-faker-extension'


### PR DESCRIPTION
Experiment for https://github.com/wiremock/community/issues/44. It needs the plugin to be accepted to the gradle plugins repo before it can be actually tested on CI

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
