### PR TITLE
Adds support for seed hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ new WireMockServer(wireMockConfig().extensions(RandomExtension.class));
 
 This will generate random first names in the `en-US` locale for every request.
 
+You can optionally add the `seed` parameter to generate the same value for the same seed:
+
+{% raw %}
+```handlebars
+{{ random 'Name.first_name' seed=1234 }}
+```
+%}
 
 ### Technical notes
 This library brings `net.datafaker:datafaker` as transitive dependency, which may result in conflicts at building time. 

--- a/src/main/java/org/wiremock/RandomHelper.java
+++ b/src/main/java/org/wiremock/RandomHelper.java
@@ -2,12 +2,15 @@ package org.wiremock;
 
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
+import java.util.Random;
 import net.datafaker.Faker;
 
 /*
  * Author: Shreya Agarwal
  */
 public class RandomHelper extends HandlebarsHelper<Object> {
+
+  private static final String SEED_HASH = "seed";
 
   private final Faker faker;
 
@@ -17,13 +20,18 @@ public class RandomHelper extends HandlebarsHelper<Object> {
 
   @Override
   public Object apply(Object context, Options options) {
+
+    // Use a seeded Faker if seed hash exists
+    final var seedOption = options.hash(SEED_HASH);
+    var myFaker = seedOption == null ? faker : new Faker(new Random(seedOption.hashCode()));
+
     try {
       // Used the `expression` method instead of `resolve` as the
       // resolve method is not able to resolve nested references in the yml files. For example, in
       // the resource file for en-US, `address.full_address` wasn't resolving because of the
       // `#{street_address}` nested reference, but `address.postcode_by_state.AL` would work fine.
       // `expression` is able to handle all cases.
-      return faker.expression("#{" + context + "}");
+      return myFaker.expression("#{" + context + "}");
     } catch (RuntimeException e) {
       return handleError("Unable to evaluate the expression " + context, e);
     }

--- a/src/test/java/org/wiremock/RandomHelperTest.java
+++ b/src/test/java/org/wiremock/RandomHelperTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelperTestBase;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.Random;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,18 @@ public class RandomHelperTest extends HandlebarsHelperTestBase {
     newFaker.set(helper, new Faker(new Random(seed)));
 
     String actual = renderHelperValue(helper, expression);
+    assertThat(actual, is(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "1, Donny",
+        "toto, Ethan",
+      })
+  public void rendersSeededRandomValue(Object seed, String expected) throws IOException {
+    final var actual = helper.apply("Name.firstName", createOptions(Map.of("seed", seed)));
+
     assertThat(actual, is(expected));
   }
 }


### PR DESCRIPTION
Adds support for "seed" hash.

## References

- Allow for seeding the Faker instance #1

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
