### PR TITLE
Adds support for locale hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ new WireMockServer(wireMockConfig().extensions(RandomExtension.class));
 
 This will generate random first names in the `en-US` locale for every request.
 
-You can optionally add the `seed` parameter to generate the same value for the same seed:
+You can optionally add:
+* the `seed` parameter to always generate the same value for the same seed
+* the `locale` parameter to generate values in a specific locale
+
+{% raw %}
+```handle
 
 {% raw %}
 ```handlebars
-{{ random 'Name.first_name' seed=1234 }}
+{{ random 'Name.first_name' seed=1234 locale='es' }}
 ```
 %}
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ new WireMockServer(wireMockConfig().extensions(RandomExtension.class));
 
 This will generate random first names in the `en-US` locale for every request.
 
+You can optionally add the `seed` parameter to generate the same value for the same seed:
+
+{% raw %}
+```handlebars
+{{ random 'Name.first_name' seed=1234 }}
+```
+%}
 
 ### Technical notes
 This library brings `net.datafaker:datafaker` as transitive dependency, which may result in conflicts at building time. 

--- a/src/main/java/org/wiremock/RandomHelper.java
+++ b/src/main/java/org/wiremock/RandomHelper.java
@@ -4,6 +4,7 @@ import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
 import java.util.Random;
 import net.datafaker.Faker;
+import org.apache.commons.lang3.LocaleUtils;
 
 /*
  * Author: Shreya Agarwal
@@ -11,19 +12,25 @@ import net.datafaker.Faker;
 public class RandomHelper extends HandlebarsHelper<Object> {
 
   private static final String SEED_HASH = "seed";
+  private static final String LOCALE_HASH = "locale";
 
+  private final Random random;
   private final Faker faker;
 
   public RandomHelper() {
-    faker = new Faker();
+    this(new Random());
+  }
+
+  RandomHelper(Random random) {
+    this.random = random;
+    this.faker = new Faker(random);
   }
 
   @Override
   public Object apply(Object context, Options options) {
 
-    // Use a seeded Faker if seed hash exists
-    final var seedOption = options.hash(SEED_HASH);
-    var myFaker = seedOption == null ? faker : new Faker(new Random(seedOption.hashCode()));
+    // Use a seeded/localized/default Faker if `locale` or `seed` hash exist
+    final Faker myFaker = this.getFaker(options.hash(SEED_HASH), options.hash(LOCALE_HASH));
 
     try {
       // Used the `expression` method instead of `resolve` as the
@@ -35,5 +42,19 @@ public class RandomHelper extends HandlebarsHelper<Object> {
     } catch (RuntimeException e) {
       return handleError("Unable to evaluate the expression " + context, e);
     }
+  }
+
+  private Faker getFaker(Object seed, String locale) {
+    final Faker myFaker;
+    if (seed != null && locale != null) {
+      myFaker = new Faker(LocaleUtils.toLocale(locale), new Random(seed.hashCode()));
+    } else if (seed != null) {
+      myFaker = new Faker(new Random(seed.hashCode()));
+    } else if (locale != null) {
+      myFaker = new Faker(LocaleUtils.toLocale(locale), this.random);
+    } else {
+      myFaker = this.faker;
+    }
+    return myFaker;
   }
 }

--- a/src/main/java/org/wiremock/RandomHelper.java
+++ b/src/main/java/org/wiremock/RandomHelper.java
@@ -2,12 +2,15 @@ package org.wiremock;
 
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
+import java.util.Random;
 import net.datafaker.Faker;
 
 /*
  * Author: Shreya Agarwal
  */
 public class RandomHelper extends HandlebarsHelper<Object> {
+
+  private static final String SEED_HASH = "seed";
 
   private final Faker faker;
 
@@ -17,13 +20,18 @@ public class RandomHelper extends HandlebarsHelper<Object> {
 
   @Override
   public Object apply(Object context, Options options) {
+
+    // Use a seeded Faker if seed hash exists
+    final var seedOption = options.hash(SEED_HASH);
+    var myFaker = seedOption == null ? faker : new Faker(new Random(seedOption.hashCode()));
+
     try {
       // Used the `expression` method instead of `resolve` as the
       // resolve method is not able to resolve nested references in the yml files. For example, in
       // the resource file for en-US, `address.full_address` wasn't resolving because of the
       // `#{street_address}` nested reference, but `address.postcode_by_state.AL` would work fine.
       // `expression` is able to handle all cases.
-      return faker.expression("#{" + context + "}");
+      return myFaker.expression("#{" + context + "}");
     } catch (RuntimeException e) {
       return handleError("Unable to evaluate the expression " + context, e);
     }

--- a/src/test/java/org/wiremock/RandomHelperTest.java
+++ b/src/test/java/org/wiremock/RandomHelperTest.java
@@ -5,10 +5,8 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelperTestBase;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Map;
+import java.util.HashMap;
 import java.util.Random;
-import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,7 +17,7 @@ public class RandomHelperTest extends HandlebarsHelperTestBase {
 
   @BeforeEach
   public void init() {
-    helper = new RandomHelper();
+    helper = new RandomHelper(new Random(123456789L));
   }
 
   @Test
@@ -32,12 +30,12 @@ public class RandomHelperTest extends HandlebarsHelperTestBase {
   }
 
   @ParameterizedTest
-  @CsvSource(value = {"123456789, Name.firstName, Herb", "123456789, Name.lastName, Hauck"})
-  public void returnsRandomValue(int seed, String expression, String expected) throws Exception {
-    Field newFaker = helper.getClass().getDeclaredField("faker");
-    newFaker.setAccessible(true);
-    newFaker.set(helper, new Faker(new Random(seed)));
-
+  @CsvSource(
+      value = {
+        "Name.firstName, Herb",
+        "Name.lastName, Hauck",
+      })
+  public void returnsRandomValue(String expression, String expected) throws Exception {
     String actual = renderHelperValue(helper, expression);
     assertThat(actual, is(expected));
   }
@@ -45,11 +43,23 @@ public class RandomHelperTest extends HandlebarsHelperTestBase {
   @ParameterizedTest
   @CsvSource(
       value = {
-        "1, Donny",
-        "toto, Ethan",
+        ", , Herb",
+        ", es, José María",
+        ", fr_QC, Clément",
+        "1, , Donny",
+        "hello, , Nickie",
+        "test, de, Franz"
       })
-  public void rendersSeededRandomValue(Object seed, String expected) throws IOException {
-    final var actual = helper.apply("Name.firstName", createOptions(Map.of("seed", seed)));
+  public void rendersSeededLocalizedRandomValue(Object seed, Object locale, String expected) {
+    final var map = new HashMap<String, Object>();
+    if (seed != null) {
+      map.put("seed", seed);
+    }
+    if (locale != null) {
+      map.put("locale", locale);
+    }
+
+    final var actual = helper.apply("Name.firstName", createOptions(map));
 
     assertThat(actual, is(expected));
   }

--- a/src/test/java/org/wiremock/RandomHelperTest.java
+++ b/src/test/java/org/wiremock/RandomHelperTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelperTestBase;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.Random;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,18 @@ public class RandomHelperTest extends HandlebarsHelperTestBase {
     newFaker.set(helper, new Faker(new Random(seed)));
 
     String actual = renderHelperValue(helper, expression);
+    assertThat(actual, is(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "1, Donny",
+        "toto, Ethan",
+      })
+  public void rendersSeededRandomValue(Object seed, String expected) throws IOException {
+    final var actual = helper.apply("Name.firstName", createOptions(Map.of("seed", seed)));
+
     assertThat(actual, is(expected));
   }
 }


### PR DESCRIPTION
Please, review this PR after #13

Refactors `RandomHelper` a little bit. 

Creates and use a `default` OR `seeded` OR `localized` OR `seededAndLocalized` faker, according to given hash.

Adds a Random field to make unit testing easier. (Especially for `localizedNonSeeded` faker)
Adds a `package private` constructor for tests.

## References

Allow users to specify the locale for fake data #2

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
